### PR TITLE
ci: update CI to the latest standards

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @open-turo/github-actions

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,6 +1,0 @@
-version: 2
-updates:
-  - package-ecosystem: github-actions
-    directory: /
-    schedule:
-      interval: daily

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["github>open-turo/renovate-config#v1"]
+}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,7 +10,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: open-turo/actions-gha/lint@v1
-
   test:
     name: Test
     runs-on: ubuntu-latest
@@ -22,10 +21,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout this repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Search for comment within PR
         id: before-add-fc
-        uses: peter-evans/find-comment@v2
+        uses: peter-evans/find-comment@v3
         with:
           issue-number: ${{ github.event.pull_request.number }}
           comment-author: open-turo-bot
@@ -50,7 +49,7 @@ jobs:
           github-token: ${{ secrets.OPEN_TURO_GITHUB_TOKEN }}
       - name: Search for comment that should now be present on the PR
         id: after-add-fc
-        uses: peter-evans/find-comment@v2
+        uses: peter-evans/find-comment@v3
         with:
           issue-number: ${{ github.event.pull_request.number }}
           comment-author: open-turo-bot
@@ -73,7 +72,7 @@ jobs:
           github-token: ${{ secrets.OPEN_TURO_GITHUB_TOKEN }}
       - name: Search for updated comment that should be present on the PR
         id: after-update-fc
-        uses: peter-evans/find-comment@v2
+        uses: peter-evans/find-comment@v3
         with:
           issue-number: ${{ github.event.pull_request.number }}
           comment-author: open-turo-bot
@@ -96,7 +95,7 @@ jobs:
       - name: Search for comment that should now have been deleted
         id: after-delete-fc
         if: success()
-        uses: peter-evans/find-comment@v2
+        uses: peter-evans/find-comment@v3
         with:
           issue-number: ${{ github.event.pull_request.number }}
           comment-author: open-turo-bot

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,23 +11,21 @@ jobs:
     steps:
       - uses: open-turo/actions-gha/lint@v1
         with:
-          github-token: ${{ secrets.OPEN_TURO_GITHUB_TOKEN }}
-
+          github-token: ${{ secrets.GITHUB_TOKEN }}
   test:
     name: Test
     runs-on: ubuntu-latest
     steps:
       - uses: open-turo/actions-gha/test@v1
         with:
-          github-token: ${{ secrets.OPEN_TURO_GITHUB_TOKEN }}
-
+          github-token: ${{ secrets.GITHUB_TOKEN }}
   release:
     needs:
       - lint
       - test
     name: Release
     runs-on: ubuntu-latest
-    env:
-      GITHUB_TOKEN: ${{ secrets.OPEN_TURO_GITHUB_TOKEN }}
     steps:
       - uses: open-turo/actions-gha/release@v1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/update-dependencies.yaml
+++ b/.github/workflows/update-dependencies.yaml
@@ -1,0 +1,25 @@
+name: Update dependencies
+concurrency: update-dependencies
+
+on:
+  schedule:
+    # Every day at midnight
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+  issue_comment:
+    types:
+      - edited
+  pull_request:
+    types:
+      - edited
+
+jobs:
+  update-dependencies:
+    runs-on: ubuntu-latest
+    name: Update dependencies
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - uses: open-turo/action-renovate@v1
+        with:
+          github-token: ${{ secrets.OPEN_TURO_GITHUB_TOKEN }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,28 +1,32 @@
-exclude: dist/.*
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.1.0 # Use the ref you want to point at
+    rev: v4.6.0 # Use the ref you want to point at
     hooks:
       - id: check-json
       - id: check-yaml
       - id: end-of-file-fixer
       - id: trailing-whitespace
-  - repo: https://github.com/pre-commit/mirrors-eslint
-    rev: v8.9.0
-    hooks:
-      - id: eslint
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v2.5.1
+    rev: v3.1.0
     hooks:
       - id: prettier
         stages: [commit]
   - repo: https://github.com/alessandrojcm/commitlint-pre-commit-hook
-    rev: v8.0.0
+    rev: v9.16.0
     hooks:
       - id: commitlint
         stages: [commit-msg]
         additional_dependencies: ["@open-turo/commitlint-config-conventional"]
   - repo: https://github.com/rhysd/actionlint
-    rev: v1.6.8
+    rev: v1.6.27
     hooks:
       - id: actionlint
+        # actionlint doesn't like the uses: ./
+        exclude: ci.yaml
+  - repo: local
+    hooks:
+      - id: update-action-readme
+        name: update-action-readme
+        entry: ./script/update-action-readme
+        language: script
+        files: '.*action\.yaml$'

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,15 +1,3 @@
 {
-  "branches": [
-    "main",
-    {
-      "channel": "next",
-      "name": "(f|b|c)/*",
-      "prerelease": "beta-<%= (/^\\w+-\\d+/.exec(name.substr(2)) || [])[0] %>"
-    }
-  ],
-  "plugins": [
-    "@semantic-release/commit-analyzer",
-    "@semantic-release/release-notes-generator",
-    "@semantic-release/github"
-  ]
+  "extends": "@open-turo/semantic-release-config"
 }

--- a/README.md
+++ b/README.md
@@ -1,89 +1,98 @@
-# `open-turo/action-conditional-pr-comment`
+# action-conditional-pr-comment
 
-GitHub Action that supports instructing the author of a Pull Request (PR) how to
-resolve a given problem within the context of a PR. Conditionally adds a comment
-to the PR with resolution instructions, and once the condition is found to be
-resolved, allows the previously added comment, if one exists at that time, to be
-removed from the PR.
+[![Release](https://img.shields.io/github/v/release/open-turo/action-renovate)](https://github.com/open-turo/eslint-config-typescript/releases/)
+[![Tests pass/fail](https://img.shields.io/github/actions/workflow/status/open-turo/action-renovate/ci.yaml)](https://github.com/open-turo/action-renovate/actions/)
+[![License](https://img.shields.io/github/license/open-turo/action-renovate)](./LICENSE)
+[![Contributions welcome](https://img.shields.io/badge/contributions-welcome-brightgreen.svg)](https://github.com/dwyl/esta/issues)
+![CI](https://github.com/open-turo/action-renovate/actions/workflows/release.yaml/badge.svg)
+[![semantic-release: angular](https://img.shields.io/badge/semantic--release-angular-e10079?logo=semantic-release)](https://github.com/semantic-release/semantic-release)
+[![Conventional commits](https://img.shields.io/badge/conventional%20commits-1.0.2-%23FE5196?logo=conventionalcommits&logoColor=white)](https://conventionalcommits.org)
+[![Join us!](https://img.shields.io/badge/Turo-Join%20us%21-593CFB.svg)](https://turo.com/jobs)
+
+<!-- prettier-ignore-start -->
+<!-- action-docs-description source="action.yaml" -->
+## Description
+
+GitHub Action that supports instructing the author of a Pull Request (PR) how to resolve a given problem within the context of a PR. Conditionally adds a comment to the PR with resolution instructions, and once the condition is found to be resolved, allows the previously added comment, if one exists at that time, to be removed from the PR.
+<!-- action-docs-description source="action.yaml" -->
+## Description
+
+GitHub Action that publishes a new release.
+<!-- action-docs-description -->
+<!-- prettier-ignore-end -->
 
 ## Usage
 
-Note that the `if: failure()` guard clause is present to indicate a problem of a
-given type has been detected to exist, and thus in that event the conditional PR
-comment action is engaged.
-
-### Instruct PR author to run npm run prepare, delete PR comment upon resolution
-
 ```yaml
 jobs:
-    do-something:
+    build:
         steps:
-            - name: Do something ...
-            - uses: open-turo/action-conditional-pr-comment@v1
-              if: failure()
+            - name: Update dependencies
+              uses: open-turo/action-renovate@v1
               with:
-                  workflow: ADD
-                  text-detector: npm run prepare
-                  github-token: ${{ secrets.GITHUB_TOKEN }}
-                  comment:
-                      Please run `npm run prepare` locally, then push those
-                      changes to this PR
-```
-
-### Instruct PR author to run npm run prepare, retain PR comment upon resolution
-
-```yaml
-jobs:
-    do-something:
-        steps:
-            - name: Do something ...
-            - uses: open-turo/action-conditional-pr-comment@v1
-              if: failure()
-              with:
-                  workflow: ADD
-                  text-detector: npm run prepare
-                  github-token: ${{ secrets.GITHUB_TOKEN }}
-                  comment:
-                      Please run `npm run prepare` locally, then push those
-                      changes to this PR
-```
-
-### Instruct PR author to run npm run prepare, delete PR comment upon resolution
-
-```yaml
-jobs:
-    do-something:
-        steps:
-            - name: Do something ...
-            - uses: open-turo/action-conditional-pr-comment@v1
-              if: failure()
-              with:
-                  workflow: ADD
-                  text-detector: npm run prepare
-                  github-token: ${{ secrets.GITHUB_TOKEN }}
-                  comment:
-                      Please run `npm run prepare` locally, then push those
-                      changes to this PR
-            - uses: open-turo/action-conditional-pr-comment@v1
-              with:
-                  workflow: REMOVE
-                  text-detector: npm run prepare
                   github-token: ${{ secrets.GITHUB_TOKEN }}
 ```
 
+<!-- prettier-ignore-start -->
+<!-- action-docs-inputs source="action.yaml" -->
 ## Inputs
 
-| parameter      | description                                                                                                                                                                                                | required | default                                    |
-| -------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | ------------------------------------------ |
-| workflow       | `ADD` indicates the `comment` is to be added/updated to/within the PR, `REMOVE` indicates the comment is to be removed from the PR.                                                                        | `true`   |                                            |
-| text-detector  | This is some unique verbatim subset of the `comment` that is to be used to determine if a comment has already been created against the PR that instructs the author how to resolve the given problem.      | `true`   | `created by action-conditional-pr-comment` |
-| github-token   | GitHub token that can create/delete comments. e.g. 'secrets.GITHUB_TOKEN'                                                                                                                                  | `true`   |                                            |
-| comment        | This is the full text of the message to be placed within a comment of the given PR to instruct the author of the PR how to resolve a given problem. This value should be provided for all `ADD` workflows. | `false`  |                                            |
-| comment-author | The author of the comment upon addition.                                                                                                                                                                   | `false`  | `open-turo-bot`                            |
+| name | description | required | default |
+| --- | --- | --- | --- |
+| `workflow` | <p>ADD indicates the comment is to be added/updated to/within the PR, REMOVE indicates the comment is to be removed from the PR.</p> | `true` | `""` |
+| `text-detector` | <p>This is some unique verbatim subset of the comment that is to be used to determine if a comment has already been created against the PR that instructs the author how to resolve the given problem.</p> | `true` | `created by action-conditional-pr-comment` |
+| `github-token` | <p>GitHub token that can add/update/delete comments. e.g. 'secrets.GITHUB_TOKEN'</p> | `true` | `""` |
+| `comment` | <p>This is the full text of the message to be placed within a comment of the given PR to instruct the author of the PR how to resolve a given problem. This value should be provided for all ADD workflows.</p> | `false` | `fixme` |
+| `comment-author` | <p>The author of the comment upon addition.</p> | `false` | `open-turo-bot` |
+<!-- action-docs-inputs source="action.yaml" -->
+## Inputs
 
+| parameter | description | required | default |
+| --- | --- | --- | --- |
+| checkout-repo | Perform checkout as first step of action | `false` | true |
+| checkout-fetch-depth | The number of commits to fetch. 0 indicates all history for all branches and tags | `false` | 0 |
+| github-token | GitHub token that can checkout the repository as well as create tags/releases against it. e.g. 'secrets.GITHUB_TOKEN' | `true` | ${{ github.token }} |
+| docker-config-file | Path to the docker config file (defaults to .docker-config.json) Must contain imageName, may contain dockerfile. | `false` | .docker-config.json |
+| docker-flavor | Docker flavor to use for docker metadata | `false` | latest=false  |
+| dockerhub-user | username for dockerhub | `false` |  |
+| dockerhub-password | password for dockerhub | `false` |  |
+| npm-auth-token | The Node Package Manager (npm) authentication token. This token is used to authenticate against a private NPM registry configured via a .npmrc file. | `false` |  |
+| npm-token | The Node Package Manager (npm) authentication token. This token is used to authenticate against the NPM registry. | `false` |  |
+| dry-run | Whether to run semantic release in `dry-run` mode. It will override the `dryRun` attribute in your configuration file | `false` | false |
+| extra-plugins | Extra plugins for pre-install. You can also specify specifying version range for the extra plugins if you prefer.  Defaults to install @open-turo/semantic-release-config. | `false` | @open-turo/semantic-release-config  |
+<!-- action-docs-inputs -->
+<!-- action-docs-outputs -->
+## Outputs
+
+| parameter | description |
+| --- | --- |
+| new-release-published | Whether a new release was published |
+| new-release-version | Version of the new release |
+| new-release-major-version | Major version of the new release |
+<!-- action-docs-outputs source="action.yaml" -->
+
+<!-- action-docs-outputs source="action.yaml" -->
+<!-- action-docs-runs -->
 ## Runs
 
-This action is an `composite` action.
+This action is a `composite` action.
+<!-- action-docs-runs source="action.yaml" -->
+## Runs
+
+This action is a `composite` action.
+<!-- action-docs-runs source="action.yaml" -->
+<!-- action-docs-usage source="action.yaml"  -->
+<!-- action-docs-usage -->
+<!-- prettier-ignore-end -->
+
+## Development
+
+Install [pre-commit](https://pre-commit.com/) and the commit hooks:
+
+```shell
+pre-commit install
+pre-commit install --hook-type commit-msg
+```
 
 ## Get Help
 

--- a/script/update-action-readme
+++ b/script/update-action-readme
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -ex
+
+for i in $*; do
+  # ignore if the file does not end with /action.yaml
+  if [[ "$i" != *"action.yaml" ]]; then
+    echo "skipping: ${i}"
+    continue
+  fi
+  readme_file=$(dirname "$i")/README.md
+  echo "npx action-docs --no-banner -a "${i}" --update-readme "${readme_file}""
+  npx action-docs@2 --no-banner -a "${i}" --update-readme "${readme_file}"
+done


### PR DESCRIPTION

**Description**

This PR updates this action to the latest standards so that we can start having dependency updates, which are missing here.

I keep thinking that it's time to have a template repo or something like that for these actions too.

**Changes**

* ci: update CI to the latest standards

🚀 PR created with [fotingo](https://github.com/tagoro9/fotingo)
