### PR TITLE
fix: use simpler method to delete the comment

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -86,8 +86,14 @@ runs:
       if:
         inputs.workflow == 'REMOVE' && steps.fc.outputs.comment-id != '' &&
         steps.pr.outputs.no-pr != 'true'
-      uses: winterjung/comment@v1
+      uses: actions/github-script@v7
+      env:
+        COMMENT_ID: ${{ steps.fc.outputs.comment-id }}
       with:
-        type: delete
-        comment_id: ${{ steps.fc.outputs.comment-id }}
-        token: ${{ inputs.github-token }}
+        github-token: ${{ inputs.github-token }}
+        script: |
+          await github.rest.issues.deleteComment({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            comment_id: parseInt(process.env.COMMENT_ID),
+          });


### PR DESCRIPTION

**Description**

This simplifies the action so we don't rely on third party action. As a side effect, this action doesn't require docker and should be able to run in arm64 runners.

**Changes**

* fix: use simpler method to delete the comment

🚀 PR created with [fotingo](https://github.com/tagoro9/fotingo)
